### PR TITLE
Fix for Issue #6: Particle System Categories for YAML 

### DIFF
--- a/operators/bbox_tracker.py
+++ b/operators/bbox_tracker.py
@@ -202,18 +202,21 @@ def compute_bounding_boxes(scene, include_save=True):
 
     elif mode == 'PARTICLE':
         emitter_list = scene.blv_settings.selected_emitter
-        
+        # get evaluated depsgraph
 
         for emitr in emitter_list:
+            cat_id = emitr.category_id
+            # for each particle emitter, get cat_id and rendered object name
 
 
-            part_bboxes, part_cat, part_name = loop_over_particles(emitr, cam, scene,
+            part_bboxes, part_cat_ids, part_names = loop_over_particles(emitr, cam, scene,
                                                         use_raycast=use_raycast,
                                                         raycast_method=raycast_method)
             if part_bboxes:
                 bboxes.extend(part_bboxes)
-                cat_ids.extend(part_cat)
-                category_mapping[cat_ids[0]] = part_name[0]
+                cat_ids.extend(part_cat_ids)
+                for cid, name in zip(part_cat_ids, part_names):
+                    category_mapping[cid] = name
 
             else:
                 num_blocked += 1

--- a/utils/bbox_utils.py
+++ b/utils/bbox_utils.py
@@ -285,8 +285,10 @@ def loop_over_particles(sel_emitter, cam, scene, *,
     for i, psys in enumerate(particle_systems):
         psys_settings = emitter_obj.particle_systems[i].settings
         cat_id = sel_emitter.category_id
+        cat_ids.append(cat_id)
         instance_obj = psys_settings.instance_object
         cat_name = instance_obj.name
+        cat_names.append(cat_name)
 
         if not instance_obj:
             continue
@@ -325,8 +327,8 @@ def loop_over_particles(sel_emitter, cam, scene, *,
             )
             if bb_2d:
                 bboxes.append(bb_2d)
-                cat_ids.append(cat_id)
-                cat_names.append(cat_name)
+                # cat_ids.append(cat_id)
+                # cat_names.append(cat_name)
 
     return bboxes, cat_ids, cat_names
 


### PR DESCRIPTION
Allows for multiple particle systems to be used for bounding box tracking. Before, the YAML file would only populate one category for many registered particle emitters. Now, it correctly assigns category names (via object name) and category ID's based on the ID chosen in the add-on GUI. 